### PR TITLE
Removed __makeref usage for IL2CPP

### DIFF
--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Camera/CullingGroupEventTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Camera/CullingGroupEventTests.cs
@@ -80,14 +80,13 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Camera
             byte prevStateByte = (byte)prevState;
             byte thisStateByte = (byte)thisState;
 
-            var instance = new CullingGroupEvent();
-            TypedReference reference = __makeref(instance);
-            
-            _indexField.SetValueDirect(reference, index);
-            _prevStateField.SetValueDirect(reference, prevStateByte);
-            _thisStateField.SetValueDirect(reference, thisStateByte);
+            object boxed = new CullingGroupEvent();
 
-            return instance;
+            _indexField.SetValue(boxed, index);
+            _prevStateField.SetValue(boxed, prevStateByte);
+            _thisStateField.SetValue(boxed, thisStateByte);
+
+            return (CullingGroupEvent)boxed;
         }
 
         private static byte AsVisibility(bool isVisible)

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics2D/ColliderDistance2DTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics2D/ColliderDistance2DTests.cs
@@ -74,6 +74,7 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics2D
             Assert.AreNotEqual(normal, new Vector2());
         }
 
+#if !ENABLE_IL2CPP
         [Test]
         public void CanSetNormalViaReference()
         {
@@ -95,5 +96,6 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics2D
             Assert.AreEqual(normal, value.normal);
             Assert.AreNotEqual(normal, new Vector2());
         }
+#endif
     }
 }

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Random/RandomStateTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Random/RandomStateTests.cs
@@ -78,6 +78,7 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Random
             Assert.AreEqual(newValue, field.GetValue(boxed));
         }
 
+#if !ENABLE_IL2CPP
         [Test]
         public void CanSetStateViaReference()
         {
@@ -97,5 +98,6 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Random
             // Assert
             Assert.AreEqual(newValue, field.GetValue(value));
         }
+#endif
     }
 }

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Camera/CullingGroupEventConverter.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Camera/CullingGroupEventConverter.cs
@@ -46,9 +46,18 @@ namespace Newtonsoft.Json.UnityConverters.Camera
             byte currentDistance = values.GetAsTypeOrDefault<byte>(3);
             byte previousDistance = values.GetAsTypeOrDefault<byte>(4);
 
-            int thisStateByte = (byte)(isVisibleByte | (currentDistance & DISTANCE_MASK));
-            int prevStateByte = (byte)(wasVisibleByte | (previousDistance & DISTANCE_MASK));
+            byte thisStateByte = (byte)(isVisibleByte | (currentDistance & DISTANCE_MASK));
+            byte prevStateByte = (byte)(wasVisibleByte | (previousDistance & DISTANCE_MASK));
 
+#if ENABLE_IL2CPP
+            object boxed = new CullingGroupEvent();
+
+            _indexField.SetValue(boxed, index);
+            _prevStateField.SetValue(boxed, prevStateByte);
+            _thisStateField.SetValue(boxed, thisStateByte);
+
+            return (CullingGroupEvent)boxed;
+#else
             var instance = new CullingGroupEvent();
             TypedReference reference = __makeref(instance);
 
@@ -57,6 +66,7 @@ namespace Newtonsoft.Json.UnityConverters.Camera
             _thisStateField.SetValueDirect(reference, thisStateByte);
 
             return instance;
+#endif
         }
 
         protected override object[] ReadInstanceValues(CullingGroupEvent instance)

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Physics2D/ColliderDistance2DConverter.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Physics2D/ColliderDistance2DConverter.cs
@@ -31,12 +31,21 @@ namespace Newtonsoft.Json.UnityConverters.Physics2D
                 throw new JsonException("Failed to set value for 'm_Normal' field on UnityEngine.ColliderDistance2D type.");
             }
 
-            TypedReference reference = __makeref(instance);
             Vector2 normal = values.GetAsTypeOrDefault<Vector2>(2);
+
+#if ENABLE_IL2CPP
+            object boxed = instance;
+
+            _normalField.SetValue(boxed, normal);
+
+            return (ColliderDistance2D)boxed;
+#else
+            TypedReference reference = __makeref(instance);
 
             _normalField.SetValueDirect(reference, normal);
 
             return instance;
+#endif
         }
 
         protected override object[] ReadInstanceValues(ColliderDistance2D instance)

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Random/RandomStateConverter.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Random/RandomStateConverter.cs
@@ -24,13 +24,21 @@ namespace Newtonsoft.Json.UnityConverters.Random
         {
             var state = new RandomState();
 
+#if ENABLE_IL2CPP
+            object boxed = state;
+            _s0Field.SetValue(boxed, values[0]);
+            _s1Field.SetValue(boxed, values[1]);
+            _s2Field.SetValue(boxed, values[2]);
+            _s3Field.SetValue(boxed, values[3]);
+            return (RandomState)boxed;
+#else
             TypedReference reference = __makeref(state);
             _s0Field.SetValueDirect(reference, values[0]);
             _s1Field.SetValueDirect(reference, values[1]);
             _s2Field.SetValueDirect(reference, values[2]);
             _s3Field.SetValueDirect(reference, values[3]);
-
             return state;
+#endif
         }
 
         protected override int[] ReadInstanceValues(RandomState instance)


### PR DESCRIPTION
IL2CPP doesn't handle setting fields via `TypedReference`, so I changed to use the boxing variant.

Keeping the TypedReference for non-IL2CPP builds though as it's faster and doesn't allocate any heap.

Uses the `ENABLE_IL2CPP` platform define directive to filter on IL2CPP builds.

Fixes #34 