### PR TITLE
Added support for populating values

### DIFF
--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Issues/Issue20_Populating.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Issues/Issue20_Populating.cs
@@ -1,0 +1,51 @@
+using UnityEngine;
+using NUnit.Framework;
+
+namespace Newtonsoft.Json.UnityConverters.Tests
+{
+    public class Issue20_Populating : TypeTesterBase
+    {
+        [Test]
+        public void PopulatesExistingProperty()
+        {
+            // Arrange
+            // Wrapping in yet another object for Newtonsoft.Json's populate
+            // algo to really kick in.
+            // Otherwise it just seems to do JSON diffing
+            var input = new MyClass { MyProperty = new Vector3(1, 2, 3) };
+            var json = Serialize(new { MyProperty = new { y = 8 }});
+            var expectedProp = new Vector3(1, 8, 3);
+
+            // Act
+            Populate(json, input);
+
+            // Assert
+            Assert.AreEqual(expectedProp, input.MyProperty, "JSON: " + json);
+        }
+
+        [Test]
+        public void PopulatesExistingField()
+        {
+            // Arrange
+            // Wrapping in yet another object for Newtonsoft.Json's populate
+            // algo to really kick in.
+            // Otherwise it just seems to do JSON diffing
+            var input = new MyClass { myField = new Vector3(4, 5, 6) };
+            var json = Serialize(new { myField = new { y = 9 }});
+            var expectedField = new Vector3(4, 9, 6);
+
+            // Act
+            Populate(json, input);
+
+            // Assert
+            Assert.AreEqual(expectedField, input.myField, "JSON: " + json);
+        }
+
+        private class MyClass
+        {
+            public Vector3 MyProperty { get; set; }
+
+            public Vector3 myField;
+        }
+    }
+}

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Issues/Issue20_Populating.cs.meta
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Issues/Issue20_Populating.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3aec8b679c1ed7e4d963e47eaf2aa607
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/NativeArray/NativeArrayTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/NativeArray/NativeArrayTests.cs
@@ -46,7 +46,7 @@ namespace Newtonsoft.Json.UnityConverters.Tests.NativeArray
 
             // Assert
             StringAssert.StartsWith(
-                "Deserializing NativeArray<> and NativeSlice<> is disabled to not cause accidental memory leaks. Use regular List<> or array types instead.",
+                "Deserializing NativeArray<> and NativeSlice<> is disabled to not cause accidental memory leaks. Use regular List<> or array types instead in your JSON models.",
                 ex.Message,
                 ex.ToString()
             );
@@ -86,7 +86,7 @@ namespace Newtonsoft.Json.UnityConverters.Tests.NativeArray
 
             // Assert
             StringAssert.StartsWith(
-                "Deserializing NativeArray<> and NativeSlice<> is disabled to not cause accidental memory leaks. Use regular List<> or array types instead.",
+                "Deserializing NativeArray<> and NativeSlice<> is disabled to not cause accidental memory leaks. Use regular List<> or array types instead in your JSON models.",
                 ex.Message,
                 ex.ToString()
             );

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/TypeTester.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/TypeTester.cs
@@ -63,6 +63,16 @@ namespace Newtonsoft.Json.UnityConverters.Tests
             return serializer.Deserialize<T>(new JsonTextReader(new StringReader(json)));
         }
 
+        protected void Populate(string json, object existingValue)
+        {
+            Populate(json, existingValue, _serializer);
+        }
+
+        protected void Populate(string json, object existingValue, JsonSerializer serializer)
+        {
+            serializer.Populate(new JsonTextReader(new StringReader(json)), existingValue);
+        }
+
         public static string GetTypeNameWithAssembly(Type type)
         {
             string assemblyName = type.Assembly.FullName;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   `RandomStateConverter`
   ([#35](https://github.com/jilleJr/Newtonsoft.Json-for-Unity.Converters/issues/35))
 
+- Added support for populating using `JsonConvert.PopulateObject` when using
+  any of the custom converters. ([#49](https://github.com/jilleJr/Newtonsoft.Json-for-Unity.Converters/issues/49))
+
 - Removed the array passing and reflection in the PartialConverter and removed
   all partial converters except `PartialConverter.cs`, simplifying the code a
   lot. This should lead to a minor performance boost as well.

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/NativeArray/NativeArrayConverter.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/NativeArray/NativeArrayConverter.cs
@@ -34,7 +34,7 @@ namespace Newtonsoft.Json.UnityConverters.NativeArray
             }
 
             throw reader.CreateSerializationException(
-                "Deserializing NativeArray<> and NativeSlice<> is disabled to not cause accidental memory leaks. Use regular List<> or array types instead."
+                "Deserializing NativeArray<> and NativeSlice<> is disabled to not cause accidental memory leaks. Use regular List<> or array types instead in your JSON models. Due to technical limitations, we cannot even populate existing NativeArray<> or NativeSlice<> values. You simply have to use other collection types."
             );
         }
 

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/PartialConverter.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/PartialConverter.cs
@@ -74,11 +74,11 @@ namespace Newtonsoft.Json.UnityConverters
                 return isNullableStruct ? null : (object)default(T);
             }
 
-            return InternalReadJson(reader, serializer);
+            return InternalReadJson(reader, serializer, existingValue);
         }
 
         [return: MaybeNull]
-        private T InternalReadJson(JsonReader reader, JsonSerializer serializer)
+        private T InternalReadJson(JsonReader reader, JsonSerializer serializer, [AllowNull] object existingValue)
         {
             if (reader.TokenType != JsonToken.StartObject)
             {
@@ -87,7 +87,11 @@ namespace Newtonsoft.Json.UnityConverters
 
             reader.Read();
 
-            var value = new T();
+            if (!(existingValue is T value))
+            {
+                value = new T();
+            }
+            
             string previousName = null;
             
             while (reader.TokenType == JsonToken.PropertyName)


### PR DESCRIPTION
Populating can now be done, as proven by tests.

The foundation laid down by #48 made this much simpler. Any converter based on `PartialConverter<T>` will now support populating objects.


