### PR TITLE
Fixed loading Newtonsoft.Json converters

### DIFF
--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Issues/Issue20_Populating.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Issues/Issue20_Populating.cs
@@ -1,5 +1,5 @@
-using UnityEngine;
 using NUnit.Framework;
+using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Tests
 {
@@ -12,15 +12,15 @@ namespace Newtonsoft.Json.UnityConverters.Tests
             // Wrapping in yet another object for Newtonsoft.Json's populate
             // algo to really kick in.
             // Otherwise it just seems to do JSON diffing
-            var input = new MyClass { MyProperty = new Vector3(1, 2, 3) };
-            var json = Serialize(new { MyProperty = new { y = 8 }});
+            var input = new MyClass { myProperty = new Vector3(1, 2, 3) };
+            string json = Serialize(new { myProperty = new { y = 8 } });
             var expectedProp = new Vector3(1, 8, 3);
 
             // Act
             Populate(json, input);
 
             // Assert
-            Assert.AreEqual(expectedProp, input.MyProperty, "JSON: " + json);
+            Assert.AreEqual(expectedProp, input.myProperty, "JSON: " + json);
         }
 
         [Test]
@@ -31,7 +31,7 @@ namespace Newtonsoft.Json.UnityConverters.Tests
             // algo to really kick in.
             // Otherwise it just seems to do JSON diffing
             var input = new MyClass { myField = new Vector3(4, 5, 6) };
-            var json = Serialize(new { myField = new { y = 9 }});
+            string json = Serialize(new { myField = new { y = 9 } });
             var expectedField = new Vector3(4, 9, 6);
 
             // Act
@@ -43,7 +43,7 @@ namespace Newtonsoft.Json.UnityConverters.Tests
 
         private class MyClass
         {
-            public Vector3 MyProperty { get; set; }
+            public Vector3 myProperty { get; set; }
 
             public Vector3 myField;
         }

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Issues/Issue55_StringEnumConverter.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Issues/Issue55_StringEnumConverter.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.Scripting;
+
+namespace Newtonsoft.Json.UnityConverters.Tests
+{
+    public class Issue55_StringEnumConverter : TypeTesterBase
+    {
+        [Test]
+        public void SerializesCorrectly()
+        {
+            // Arrange
+            var myType = new MyType {
+                myInt = 5,
+                mySpaceEnum = Space.Self,
+            };
+
+            // Act
+            string result = Serialize(myType);
+
+            // Assert
+            JObject jobj = Deserialize<JObject>(result);
+            Assert.IsTrue(jobj.ContainsKey("mySpaceEnum"));
+
+            JToken mySpaceEnumToken = jobj["mySpaceEnum"];
+            Assert.AreEqual(JTokenType.String, mySpaceEnumToken.Type, "JSON: " + result);
+            Assert.AreEqual("Self", mySpaceEnumToken.Value<string>());
+        }
+
+        [Preserve]
+        public struct MyType
+        {
+            public int myInt;
+            public Space mySpaceEnum;
+        }
+    }
+}

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Issues/Issue55_StringEnumConverter.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Issues/Issue55_StringEnumConverter.cs
@@ -22,11 +22,10 @@ namespace Newtonsoft.Json.UnityConverters.Tests
 
             // Assert
             JObject jobj = Deserialize<JObject>(result);
-            Assert.IsTrue(jobj.ContainsKey("mySpaceEnum"));
-
             JToken mySpaceEnumToken = jobj["mySpaceEnum"];
+            Assert.IsNotNull(mySpaceEnumToken, "JSON: " + result);
             Assert.AreEqual(JTokenType.String, mySpaceEnumToken.Type, "JSON: " + result);
-            Assert.AreEqual("Self", mySpaceEnumToken.Value<string>());
+            Assert.AreEqual("Self", mySpaceEnumToken.Value<string>(), "JSON: " + result);
         }
 
         [Preserve]

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Issues/Issue55_StringEnumConverter.cs.meta
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Issues/Issue55_StringEnumConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92e661e9b69ffb8d4a98431c3082b75a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Build/version.json
+++ b/Build/version.json
@@ -1,8 +1,7 @@
 {
   "Major": 1,
   "Minor": 1,
-  "Patch": 0,
+  "Patch": 1,
   "Suffix": "",
-
   "AutoDeployLiveRun": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Unity Converters for Newtonsoft.Json changelog
 
+## 1.1.1 (WIP)
+
+- Fixed Newtonsoft.Json converters (ex: `StringEnumConverter` &
+  `VersionConverter`) not being loaded even if you had then enabled in the
+  Newtonsoft.Json-for-Unity.Converters config.
+  ([#55](https://github.com/jilleJr/Newtonsoft.Json-for-Unity.Converters/issues/55))
+
 ## 1.1.0 (2021-04-05)
 
 - Added configurability to enable/disable any converter that was all previously

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Configuration/ConverterConfig.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Configuration/ConverterConfig.cs
@@ -14,6 +14,11 @@ namespace Newtonsoft.Json.UnityConverters.Configuration
 
         public List<KeyedConfig> settings;
 
+        public override string ToString()
+        {
+            return $"{{enabled={enabled}, converterName={converterName}, settings=[{settings?.Count ?? 0}]}}";
+        }
+
         public override bool Equals(object obj)
         {
             return obj is ConverterConfig config && Equals(config);

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Editor/UnityConvertersConfigEditor.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Editor/UnityConvertersConfigEditor.cs
@@ -2,10 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using Newtonsoft.Json.UnityConverters.Configuration;
-using Newtonsoft.Json.UnityConverters.Utility;
 using UnityEditor;
 using UnityEditor.AnimatedValues;
 using UnityEngine;
+// Unity 2020 also has a type cache: UnityEditor.TypeCache:
+// https://docs.unity3d.com/2019.2/Documentation/ScriptReference/TypeCache.html
+using TypeCache = Newtonsoft.Json.UnityConverters.Utility.TypeCache;
 
 namespace Newtonsoft.Json.UnityConverters.Editor
 {

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Properties.meta
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Properties.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 68cb0d886e404ce22bf516baa70cc565
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Properties/AssemblyInfo.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Properties/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Newtonsoft.Json.UnityConverters.Editor")]

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Properties/AssemblyInfo.cs.meta
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Properties/AssemblyInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb2756b550ea8855987f5b4f536aa544
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/UnityConverterInitializer.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/UnityConverterInitializer.cs
@@ -29,6 +29,7 @@ using System.Linq;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.UnityConverters.Configuration;
 using Newtonsoft.Json.UnityConverters.Helpers;
+using Newtonsoft.Json.UnityConverters.Utility;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters
@@ -114,7 +115,8 @@ namespace Newtonsoft.Json.UnityConverters
         {
             var config = Resources.Load<UnityConvertersConfig>(UnityConvertersConfig.PATH_FOR_RESOURCES_LOAD);
 
-            if (!config) {
+            if (!config)
+            {
                 config = ScriptableObject.CreateInstance<UnityConvertersConfig>();
             }
 
@@ -219,7 +221,7 @@ namespace Newtonsoft.Json.UnityConverters
 
             var typesOfEnabledThroughConfig = configs
                 .Where(o => o.enabled)
-                .Select(o => Type.GetType(o.converterName))
+                .Select(o => TypeCache.FindType(o.converterName))
                 .Where(o => o != null);
 
             var hashMap = new HashSet<Type>(typesOfEnabledThroughConfig);

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Utility.meta
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Utility.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: be2311fc6c15a5932b0fe5ccc74b90d7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Utility/TypeCache.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Utility/TypeCache.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Newtonsoft.Json.UnityConverters.Utility
+{
+    internal static class TypeCache
+    {
+        private static readonly Dictionary<string, Type> _typeByName
+            = new Dictionary<string, Type>();
+
+        private static readonly Assembly[] _assemblies
+            = AppDomain.CurrentDomain.GetAssemblies()
+                // Reversing so we get last imported assembly first.
+                // When searching for types we want to look in mscorlib last
+                // and Newtonsoft.Json up as the first ones
+                .Reverse()
+                .ToArray();
+
+        public static Type FindType(string name)
+        {
+            if (_typeByName.TryGetValue(name, out var type))
+            {
+                return type;
+            }
+            else
+            {
+                // Check this assembly, or if it has AssemblyQualifiedName
+                type = Type.GetType(name);
+                if (type != null)
+                {
+                    _typeByName[name] = type;
+                    return type;
+                }
+
+                // Check all the other assemblies, from last imported to first
+                foreach (var assembly in _assemblies)
+                {
+                    type = assembly.GetType(name);
+                    if (type != null)
+                    {
+                        _typeByName[name] = type;
+                        return type;
+                    }
+                }
+                return null;
+            }
+        }
+    }
+}

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Utility/TypeCache.cs.meta
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Utility/TypeCache.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c5759cb3285e6f0de86441be445ae8bd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Was mostly a regression from v1.0.0 -> v1.1.0

When filtering types in `UnityConverterInitializer.cs` I forgot that `Type.GetType` only looks in the current assembly. I switched to using the `FindType` method I created for the editor before.

## Changes

- Minor field renames
- Take use of FindType in UnityConverterInitializer

---

Resolves #55
