### PR TITLE
Make AI, Physics, and Physics2D modules optional dependencies

### DIFF
--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/AI/NavMesh/NavMeshHitTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/AI/NavMesh/NavMeshHitTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if AI_MODULE
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.AI;
 
@@ -30,3 +31,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.AI.NavMesh
         };
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/AI/NavMesh/NavMeshLinkDataTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/AI/NavMesh/NavMeshLinkDataTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if AI_MODULE
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.AI;
 
@@ -36,3 +37,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.AI.NavMesh
         };
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/AI/NavMesh/NavMeshQueryFilterTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/AI/NavMesh/NavMeshQueryFilterTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if AI_MODULE
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -84,3 +85,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.AI.NavMesh
         }
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/AI/NavMesh/NavMeshTriangulationTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/AI/NavMesh/NavMeshTriangulationTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if AI_MODULE
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using UnityEngine;
@@ -70,3 +71,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.AI.NavMesh
         }
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Newtonsoft.Json.UnityConverters.Tests.asmdef
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Newtonsoft.Json.UnityConverters.Tests.asmdef
@@ -1,20 +1,40 @@
 {
     "name": "Newtonsoft.Json.UnityConverters.Tests",
+    "rootNamespace": "",
     "references": [
-        "Newtonsoft.Json.UnityConverters"
+        "Newtonsoft.Json.UnityConverters",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
-        "Newtonsoft.Json.dll"
+        "Newtonsoft.Json.dll",
+        "nunit.framework.dll"
     ],
     "autoReferenced": false,
     "defineConstraints": [
+        "UNITY_INCLUDE_TESTS",
         "UNITY_INCLUDE_TESTS"
     ],
-    "optionalUnityReferences": [
-        "TestAssemblies"
-    ]
+    "versionDefines": [
+        {
+            "name": "com.unity.modules.ai",
+            "expression": "",
+            "define": "AI_MODULE"
+        },
+        {
+            "name": "com.unity.modules.physics",
+            "expression": "",
+            "define": "PHYSICS_MODULE"
+        },
+        {
+            "name": "com.unity.modules.physics2d",
+            "expression": "",
+            "define": "PHYSICS2D_MODULE"
+        }
+    ],
+    "noEngineReferences": false
 }

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/Dynamics/JointDriveTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/Dynamics/JointDriveTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if PHYSICS_MODULE
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Physics.Dynamics
@@ -23,3 +24,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics.Dynamics
         };
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/Dynamics/JointLimitsTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/Dynamics/JointLimitsTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if PHYSICS_MODULE
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Physics.Dynamics
@@ -29,3 +30,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics.Dynamics
         };
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/Dynamics/JointMotorTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/Dynamics/JointMotorTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if PHYSICS_MODULE
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Physics.Dynamics
@@ -23,3 +24,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics.Dynamics
         };
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/Dynamics/JointSpringTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/Dynamics/JointSpringTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if PHYSICS_MODULE
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Physics.Dynamics
@@ -23,3 +24,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics.Dynamics
         };
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/Dynamics/SoftJointLimitSpringTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/Dynamics/SoftJointLimitSpringTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if PHYSICS_MODULE
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Physics.Dynamics
@@ -20,3 +21,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics.Dynamics
         };
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/Dynamics/SoftJointLimitTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/Dynamics/SoftJointLimitTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if PHYSICS_MODULE
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Physics.Dynamics
@@ -23,3 +24,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics.Dynamics
         };
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/Dynamics/WheelFrictionCurveTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/Dynamics/WheelFrictionCurveTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if PHYSICS_MODULE
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Physics.Dynamics
@@ -29,3 +30,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics.Dynamics
         };
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/QueryCommand/BoxcastCommandTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/QueryCommand/BoxcastCommandTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if PHYSICS_MODULE
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Physics.QueryCommand
@@ -32,3 +33,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics.QueryCommand
         };
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/QueryCommand/CapsulecastCommandTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/QueryCommand/CapsulecastCommandTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if PHYSICS_MODULE
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Physics.QueryCommand
@@ -32,3 +33,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics.QueryCommand
         };
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/QueryCommand/RaycastCommandTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/QueryCommand/RaycastCommandTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if PHYSICS_MODULE
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Physics.QueryCommand
@@ -29,3 +30,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics.QueryCommand
         };
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/QueryCommand/SpherecastCommandTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics/QueryCommand/SpherecastCommandTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if PHYSICS_MODULE
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Physics.QueryCommand
@@ -29,3 +30,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics.QueryCommand
         };
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics2D/ColliderDistance2DTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics2D/ColliderDistance2DTests.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if PHYSICS2D_MODULE
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
@@ -104,3 +105,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics2D
         }
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics2D/ContactFilter2DTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics2D/ContactFilter2DTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if PHYSICS2D_MODULE
+using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.UnityConverters.Physics2D;
 using NUnit.Framework;
@@ -94,3 +95,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics2D
         }
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics2D/JointAngleLimits2DTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics2D/JointAngleLimits2DTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if PHYSICS2D_MODULE
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Physics2D
@@ -11,3 +12,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics2D
         };
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics2D/JointMotor2DTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics2D/JointMotor2DTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if PHYSICS2D_MODULE
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Physics2D
@@ -11,3 +12,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics2D
         };
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics2D/JointSuspension2DTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics2D/JointSuspension2DTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if PHYSICS2D_MODULE
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Physics2D
@@ -17,3 +18,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics2D
         };
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics2D/JointTranslationLimits2DTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics2D/JointTranslationLimits2DTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if PHYSICS2D_MODULE
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Physics2D
@@ -11,3 +12,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics2D
         };
     }
 }
+#endif

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics2D/PhysicsJobOptions2DTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Physics2D/PhysicsJobOptions2DTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if PHYSICS2D_MODULE
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Tests.Physics2D
@@ -66,3 +67,4 @@ namespace Newtonsoft.Json.UnityConverters.Tests.Physics2D
         };
     }
 }
+#endif

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Newtonsoft.Json.UnityConverters.asmdef
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Newtonsoft.Json.UnityConverters.asmdef
@@ -9,5 +9,22 @@
         "Newtonsoft.Json.dll"
     ],
     "autoReferenced": true,
-    "defineConstraints": []
+    "defineConstraints": [],
+	"versionDefines": [
+        {
+            "name": "com.unity.modules.ai",
+            "expression": "",
+            "define": "AI_MODULE"
+        },
+        {
+            "name": "com.unity.modules.physics",
+            "expression": "",
+            "define": "PHYSICS_MODULE"
+        },
+        {
+            "name": "com.unity.modules.physics2d",
+            "expression": "",
+            "define": "PHYSICS2D_MODULE"
+        }
+    ]
 }

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/AI/NavMesh/NavMeshQueryFilterConverter.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/AI/NavMesh/NavMeshQueryFilterConverter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if AI_MODULE
+using System;
 using Newtonsoft.Json.UnityConverters.Helpers;
 using UnityEngine;
 using UnityEngine.AI;
@@ -51,3 +52,4 @@ namespace Newtonsoft.Json.UnityConverters.AI.NavMesh
         }
     }
 }
+#endif

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/AI/NavMesh/NavMeshTriangulationConverter.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/AI/NavMesh/NavMeshTriangulationConverter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if AI_MODULE
+using System;
 using System.Diagnostics.CodeAnalysis;
 using Newtonsoft.Json.UnityConverters.Helpers;
 using UnityEngine;
@@ -35,3 +36,4 @@ namespace Newtonsoft.Json.UnityConverters.AI.NavMesh
         }
     }
 }
+#endif

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Physics/JointDriveConverter.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Physics/JointDriveConverter.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json.UnityConverters.Helpers;
+﻿#if PHYSICS_MODULE
+using Newtonsoft.Json.UnityConverters.Helpers;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Physics
@@ -32,3 +33,4 @@ namespace Newtonsoft.Json.UnityConverters.Physics
         }
     }
 }
+#endif

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Physics/JointLimitsConverter.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Physics/JointLimitsConverter.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json.UnityConverters.Helpers;
+﻿#if PHYSICS_MODULE
+using Newtonsoft.Json.UnityConverters.Helpers;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Physics
@@ -42,3 +43,4 @@ namespace Newtonsoft.Json.UnityConverters.Physics
         }
     }
 }
+#endif

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Physics/SoftJointLimitConverter.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Physics/SoftJointLimitConverter.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json.UnityConverters.Helpers;
+﻿#if PHYSICS_MODULE
+using Newtonsoft.Json.UnityConverters.Helpers;
 using UnityEngine;
 
 namespace Newtonsoft.Json.UnityConverters.Physics
@@ -32,3 +33,4 @@ namespace Newtonsoft.Json.UnityConverters.Physics
         }
     }
 }
+#endif

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Physics2D/ColliderDistance2DConverter.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Physics2D/ColliderDistance2DConverter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if PHYSICS2D_MODULE
+using System;
 using System.Reflection;
 using Newtonsoft.Json.UnityConverters.Helpers;
 using UnityEngine;
@@ -46,3 +47,4 @@ namespace Newtonsoft.Json.UnityConverters.Physics2D
         }
     }
 }
+#endif

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Physics2D/ContactFilter2DConverter.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Physics2D/ContactFilter2DConverter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if PHYSICS2D_MODULE
+using System;
 using Newtonsoft.Json.UnityConverters.Helpers;
 using UnityEngine;
 
@@ -75,3 +76,4 @@ namespace Newtonsoft.Json.UnityConverters.Physics2D
         }
     }
 }
+#endif


### PR DESCRIPTION
There's currently no possibility to use Converters with AI or Physics modules being disabled. However, not every project uses the AI module, etc. Thus, I made those modules optional dependencies. I created predefined symbols, like AI_MODULE, through [version defines](https://docs.unity3d.com/Manual/class-AssemblyDefinitionImporter.html#version-defines) and wrapped code in them so that it is excluded from the compilation when a module is disabled.