### PR TITLE
Release v1.4.0

### DIFF
--- a/Build/version.json
+++ b/Build/version.json
@@ -3,5 +3,5 @@
   "Minor": 4,
   "Patch": 0,
   "Suffix": "",
-  "AutoDeployLiveRun": false
+  "AutoDeployLiveRun": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Unity Converters for Newtonsoft.Json changelog
 
-## 1.4.0 (WIP)
+## 1.4.0 (2022-02-05)
 
 - Added support for `UnityEngine.AddressableAssets.AssetReference`.
   The new `AssetReferenceConverter` is only included in the build if your
-  project contains the `com.unity.addressables` package.
+  project contains the `com.unity.addressables` package. 
+  ([#67](https://github.com/jilleJr/Newtonsoft.Json-for-Unity.Converters/pull/67))
 
   This automatic inclusion relies on AssemblyDefinition version defines, which
   was introduced in Unity 2019.1.x. To enable the `AssetReferenceConverter` in


### PR DESCRIPTION
## Changes

- Added support for `UnityEngine.AddressableAssets.AssetReference`. The new `AssetReferenceConverter` is only included in the build if your project contains the `com.unity.addressables` package. ([#66](https://github.com/jilleJr/Newtonsoft.Json-for-Unity.Converters/issues/66), [#67](https://github.com/jilleJr/Newtonsoft.Json-for-Unity.Converters/pull/67))

  This automatic inclusion relies on AssemblyDefinition version defines, which was introduced in Unity 2019.1.x. To enable the `AssetReferenceConverter` in earlier versions of Unity, please add `HAVE_MODULE_ADDRESSABLES` to your project's "Scripting Define Symbols" found in the "Project Settings" -> "Player" -> "Other Settings" panel.
