### PR TITLE
Add support for AssetReferenceT<> serialization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,7 @@ preset-filter-test: &WORKFLOW_TEST_FILTER
   only:
     - develop
     - /^feature.*/
+    - /^pull/\d+/head$/
     - /^hotfix.*/
     - /^release.*/
 

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Addressables/AssetReferenceTTests.cs
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Addressables/AssetReferenceTTests.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+
+namespace Newtonsoft.Json.UnityConverters.Tests.Addressables
+{
+    public class AssetReferenceTTests : TypeTester<AssetReferenceT<TextAsset>>
+    {
+        public static readonly IReadOnlyCollection<(AssetReferenceT<TextAsset> deserialized, object anonymous)> representations = new (AssetReferenceT<TextAsset>, object)[] {
+            (new AssetReferenceT<TextAsset>("65ee4890b3c2b0f4db332c8305ce62bd"), "65ee4890b3c2b0f4db332c8305ce62bd"),
+            (new AssetReferenceT<TextAsset>("31d1857eb02457d4d84fd43e6f32c401"), "31d1857eb02457d4d84fd43e6f32c401"),
+            (new AssetReferenceT<TextAsset>("7446d4e9bc40aca48a68dc00da43f835"), "7446d4e9bc40aca48a68dc00da43f835"),
+            (null, null),
+        };
+
+        protected override bool AreEqual([AllowNull] AssetReferenceT<TextAsset> a, [AllowNull] AssetReferenceT<TextAsset> b)
+        {
+            return a?.AssetGUID == b?.AssetGUID;
+        }
+
+        [Test]
+        public void LoadsValidAssetTest()
+        {
+            var assetRef = Deserialize<AssetReferenceT<TextAsset>>("\"65ee4890b3c2b0f4db332c8305ce62bd\"");
+            Assert.IsNotNull(assetRef);
+            var textAsset = assetRef.LoadAssetAsync<TextAsset>().WaitForCompletion();
+            Assert.AreEqual("Some sample text inside TextFile1.txt", textAsset.text.Trim());
+        }
+
+        [Test]
+        public void SerializeEmptyGuidAsNull()
+        {
+            var assetRef = new AssetReferenceT<TextAsset>("");
+            Assert.AreEqual("", assetRef.AssetGUID);
+            string serialized = Serialize(assetRef);
+            Assert.AreEqual("null", serialized);
+        }
+    }
+}
+

--- a/Assets/Newtonsoft.Json.UnityConverters.Tests/Addressables/AssetReferenceTTests.cs.meta
+++ b/Assets/Newtonsoft.Json.UnityConverters.Tests/Addressables/AssetReferenceTTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f6b761302ed5261aba27f89d72af0a80
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Doc/Compatability-table.md
+++ b/Doc/Compatability-table.md
@@ -8,6 +8,7 @@ https://beautifuldingbats.com/superscript-generator/
 | Module         | Type                                                            | Can read        | Can write       | Custom converter |
 | -------------- | --------------------------------------------------------------- | --------------- | --------------- | ---------------- |
 | Addressables   | *UnityEngine.AddressableAssets*.**AssetReference**              | ✔[⁽⁷⁾](#note-7) | ✔[⁽⁷⁾](#note-7) | ✔                |
+| Addressables   | *UnityEngine.AddressableAssets*.**AssetReferenceT&lt;T&gt;**    | ✔[⁽⁷⁾](#note-7) | ✔[⁽⁷⁾](#note-7) | ✔                |
 | AI/NavMesh     | *UnityEngine.<i></i>AI*.**NavMeshDataInstance**                 | ❌[⁽²⁾](#note-2) | ❓[⁽³⁾](#note-3) | ❌[⁽²⁾](#note-2)  |
 | AI/NavMesh     | *UnityEngine.<i></i>AI*.**NavMeshHit**                          | ✔               | ✔               | ✖[⁽¹⁾](#note-1)  |
 | AI/NavMesh     | *UnityEngine.<i></i>AI*.**NavMeshLinkData**                     | ✔               | ✔               | ✖[⁽¹⁾](#note-1)  |
@@ -107,7 +108,7 @@ https://beautifuldingbats.com/superscript-generator/
   therefore has been left out. Possible to solve by using reflection tricks
   but this has been down prioritized.
 
-6. ✔<a name="note-7"></a> Support for Addressables package, which was added in
+7. ✔<a name="note-7"></a> Support for Addressables package, which was added in
   v1.4.0, is only automatically included if your Unity project has imported the
   `com.unity.addressable` package. This automatic inclusion  relies on
   AssemblyDefinition version defines, which was introduced in Unity 2019.1.x.

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Addressables/AssetReferenceConverter.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Addressables/AssetReferenceConverter.cs
@@ -8,7 +8,7 @@ namespace Newtonsoft.Json.UnityConverters.Addressables
     {
         public override bool CanConvert(Type objectType)
         {
-            return objectType == typeof(AssetReference);
+            return objectType == typeof(AssetReference) || (objectType.IsGenericType && objectType.GetGenericTypeDefinition() == typeof(AssetReferenceT<>));
         }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
@@ -20,7 +20,13 @@ namespace Newtonsoft.Json.UnityConverters.Addressables
 
             if (reader.TokenType == JsonToken.String && reader.Value is string stringValue)
             {
-                return new AssetReference(stringValue);
+                if (objectType.IsGenericType && objectType.GetGenericTypeDefinition() == typeof(AssetReferenceT<>))
+                {
+                    return Activator.CreateInstance(objectType, stringValue);
+                } else
+                {
+                    return new AssetReference(stringValue);
+                }
             }
             else
             {


### PR DESCRIPTION
Currently, attempting to serialize an AssetReferenceT (or an AssetReference derived from AssetReferenceT<>) will fail. This change would add basic support for AssetReferenceT<> serialization within the current AssetReference converter.