### PR TITLE
Added preserve to assemblies

### DIFF
--- a/Packages/Newtonsoft.Json-for-Unity.Converters/Properties/AssemblyInfo.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/Properties/AssemblyInfo.cs
@@ -1,6 +1,8 @@
 
 using System.Runtime.CompilerServices;
+using UnityEngine.Scripting;
 
+[assembly: Preserve]
 [assembly: InternalsVisibleTo("Newtonsoft.Json.UnityConverters.Addressables")]
 [assembly: InternalsVisibleTo("Newtonsoft.Json.UnityConverters.Editor")]
 [assembly: InternalsVisibleTo("Newtonsoft.Json.UnityConverters.Tests")]

--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Addressables/AssetReferenceConverter.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/Addressables/AssetReferenceConverter.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using Newtonsoft.Json.UnityConverters.Helpers;
 using UnityEngine.AddressableAssets;
+using UnityEngine.Scripting;
+
+[assembly: Preserve]
 
 namespace Newtonsoft.Json.UnityConverters.Addressables
 {


### PR DESCRIPTION
Added `[Preserve]` attribute to assemblies, so the converters never get code stripped.

Closes #72
