### PR TITLE
Release v1.5.1

### DIFF
--- a/Build/version.json
+++ b/Build/version.json
@@ -1,7 +1,7 @@
 {
   "Major": 1,
   "Minor": 5,
-  "Patch": 0,
+  "Patch": 1,
   "Suffix": "",
-  "AutoDeployLiveRun": false
+  "AutoDeployLiveRun": true
 }


### PR DESCRIPTION
## Changes

- Fixed converters being stripped when Managed Stripping Level is set to anything higher than "minimal", by adding `[Preserve]` attribute to the entire assemblies. ([#73](https://github.com/jilleJr/Newtonsoft.Json-for-Unity.Converters/pull/73))

