### PR TITLE
Prevent Stack Overflow when using Project Auditor with Newtonsoft.Json-for-Unity.Converters

### DIFF
--- a/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/ConverterGrouping.cs
+++ b/Packages/Newtonsoft.Json-for-Unity.Converters/UnityConverters/ConverterGrouping.cs
@@ -24,6 +24,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 #if UNITY_EDITOR
 #endif
 
@@ -35,6 +36,24 @@ namespace Newtonsoft.Json.UnityConverters
         public List<Type> unityConverters { get; set; }
         public List<Type> jsonNetConverters { get; set; }
 
+        /// <summary>
+        /// List of converter types that should be excluded from automatic registration
+        /// to prevent circular references or stack overflows.
+        /// </summary>
+        private static readonly HashSet<string> ExcludedConverterTypes = new HashSet<string>
+        {
+            "Unity.ProjectAuditor.Editor.Core.DescriptorJsonConverter"
+        };
+
+        /// <summary>
+        /// List of namespace patterns that should be excluded from automatic registration
+        /// to prevent circular references or stack overflows.
+        /// </summary>
+        private static readonly HashSet<string> ExcludedNamespacePatterns = new HashSet<string>
+        {
+            "Unity.ProjectAuditor"
+        };
+
         public static ConverterGrouping Create(IEnumerable<Type> types)
         {
             var grouping = new ConverterGrouping {
@@ -45,6 +64,12 @@ namespace Newtonsoft.Json.UnityConverters
 
             foreach (var converter in types)
             {
+                // Skip excluded converter types to prevent circular references
+                if (IsExcludedConverter(converter))
+                {
+                    continue;
+                }
+
                 if (converter.Namespace?.StartsWith("Newtonsoft.Json.UnityConverters") == true)
                 {
                     grouping.unityConverters.Add(converter);
@@ -60,6 +85,39 @@ namespace Newtonsoft.Json.UnityConverters
             }
 
             return grouping;
+        }
+
+        /// <summary>
+        /// Checks if a converter type should be excluded from automatic registration.
+        /// </summary>
+        /// <param name="converterType">The converter type to check.</param>
+        /// <returns>True if the converter should be excluded, false otherwise.</returns>
+        private static bool IsExcludedConverter(Type converterType)
+        {
+            if (converterType?.FullName == null)
+            {
+                return false;
+            }
+
+            // Check exact type name exclusions
+            if (ExcludedConverterTypes.Contains(converterType.FullName))
+            {
+                return true;
+            }
+
+            // Check namespace pattern exclusions
+            if (converterType.Namespace != null)
+            {
+                foreach (var excludedPattern in ExcludedNamespacePatterns)
+                {
+                    if (converterType.Namespace.StartsWith(excludedPattern))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
     }
 }


### PR DESCRIPTION
Fixes #98

This PR resolves a stack overflow that freezes Unity when the Project Auditor window is opened.

The issue was that the auto-discovery was registering Project Auditor's own `DescriptorJsonConverter`, creating an infinite recursion loop when it tried to serialize its own data.

To fix this, I've added an exclusion mechanism in `ConverterGrouping.cs` to skip registering specific converters by type or by namespace. I've added default exclusions for `Unity.ProjectAuditor.Editor.Core.DescriptorJsonConverter` and the entire `Unity.ProjectAuditor` namespace, which prevents the crash.
